### PR TITLE
T add css for Admin_login_signup and User_password_edit

### DIFF
--- a/app/assets/stylesheets/administrators/registrations/new.scss
+++ b/app/assets/stylesheets/administrators/registrations/new.scss
@@ -1,0 +1,59 @@
+.container-wrapper {
+	width: 100%;
+	height: 1152px;
+	margin: 0 auto;
+	text-align: center;
+	padding-top: 100px;
+}
+
+.containers {
+	text-align: center;
+	width: 600px;
+	margin: 0 auto;
+}
+
+.first-container, {
+	width: 400px;
+	margin: 0 auto;
+	padding: 0 50px;
+	text-align: left;
+	margin-bottom: 10px;
+
+	.field, .actions, p {
+		padding-bottom: 20px;
+		width:220px;
+		margin: 0 auto;
+	}
+
+	.postal-code {
+		padding-bottom: 20px;
+	}
+
+	span {
+		color: red;
+	}
+	.form-title {
+		width: 250px;
+		margin: 0 auto;
+		padding: 20px 0;
+		display: flex;
+		justify-content: space-around;
+
+		.sign-up, .sign-in {
+			padding: 10px 20px;
+		}
+
+		.active{
+		  color: #000;
+		  border-bottom: solid 2px;
+		}
+
+		.sign-in{
+		  color: #000;
+		}
+	}
+
+	.actions {
+		text-align: center;
+	}
+}

--- a/app/assets/stylesheets/administrators/sessions/new.scss
+++ b/app/assets/stylesheets/administrators/sessions/new.scss
@@ -1,0 +1,59 @@
+.container-wrapper {
+	width: 100%;
+	height: 1152px;
+	margin: 0 auto;
+	text-align: center;
+	padding-top: 100px;
+}
+
+.containers {
+	text-align: center;
+	width: 600px;
+	margin: 0 auto;
+}
+
+.first-container, {
+	width: 400px;
+	margin: 0 auto;
+	padding: 0 50px;
+	text-align: left;
+	margin-bottom: 10px;
+
+	.field, .actions, p {
+		padding-bottom: 20px;
+		width:220px;
+		margin: 0 auto;
+	}
+
+	.postal-code {
+		padding-bottom: 20px;
+	}
+
+	span {
+		color: red;
+	}
+	.form-title {
+		width: 250px;
+		margin: 0 auto;
+		padding: 20px 0;
+		display: flex;
+		justify-content: space-around;
+
+		.sign-up, .sign-in {
+			padding: 10px 20px;
+		}
+
+		.sign-up{
+		  color: #000;
+		}
+
+		.active{
+		  color: #000;
+		  border-bottom: solid 2px;
+		}
+	}
+
+	.actions {
+		text-align: center;
+	}
+}

--- a/app/assets/stylesheets/users/password_edit.scss
+++ b/app/assets/stylesheets/users/password_edit.scss
@@ -1,0 +1,87 @@
+.main {
+	a {
+		text-decoration: none;
+	}
+}
+
+/*背景画像は後日相談の上決定*/
+.for-background {
+	/*background: rgba(255,255,255,0.5)*/
+}
+
+.container-wrapper {
+	width: 100%;
+	height: 1152px;
+	margin: 0 auto;
+	padding-top: 100px;
+	text-align: center;
+}
+
+.containers {
+	text-align: center;
+	width: 600px;
+	margin: 0 auto;
+	background: rgba(255,255,255,0.8)
+}
+
+.first-container, {
+	width: 400px;
+	margin: 0 auto;
+	padding: 0 50px;
+	text-align: left;
+	margin-bottom: 10px;
+
+	.field, p {
+		padding-bottom: 20px;
+		width:250px;
+		margin: 0 auto;
+	}
+
+	.form-title {
+		width: 300px;
+		margin: 0 0 40px 0;
+		text-align: center;
+		border-bottom: solid 2px;
+	}
+
+	.buttons {
+		display: flex;
+		justify-content: space-around;
+	}
+
+	.update-button {
+	  display       : inline-block;
+	  font-size     : 15pt;        /* 文字サイズ */
+	  text-align    : center;      /* 文字位置   */
+	  padding       : 12px 12px;   /* 余白       */
+	  background    : rgba(0, 0, 0, 0.80);     /* 背景色     */
+	  color         : rgba(255, 255, 255, 0.8);     /* 文字色     */
+	  line-height   : 1em;         /* 1行の高さ  */
+	  transition    : .3s;         /* なめらか変化 */
+	  box-shadow    : 3px 3px 1px #666666;  /* 影の設定 */
+	  border        : 2px solid rgba(0, 0, 0, 0.8);    /* 枠の指定 */
+	}
+	.update-button:hover {
+	  box-shadow    : none;        /* カーソル時の影消去 */
+	  color         : rgba(0, 0, 0, 0.8);     /* 背景色     */
+	  background    : rgba(255, 255, 255, 0.8);     /* 文字色     */
+	}
+
+	.back-button {
+	  display       : inline-block;
+	  font-size     : 15pt;        /* 文字サイズ */
+	  text-align    : center;      /* 文字位置   */
+	  padding       : 12px 12px;   /* 余白       */
+	  background    : rgba(255, 255, 255, 0.80);     /* 背景色     */
+	  color         : rgba(0, 0, 0, 0.8);     /* 文字色     */
+	  line-height   : 1em;         /* 1行の高さ  */
+	  transition    : .3s;         /* なめらか変化 */
+	  box-shadow    : 3px 3px 1px #666666;  /* 影の設定 */
+	  border        : 2px solid rgba(0, 0, 0, 0.8);    /* 枠の指定 */
+	}
+	.back-button:hover {
+	  box-shadow    : none;        /* カーソル時の影消去 */
+	  color         : rgba(255, 255, 255, 0.8);     /* 背景色     */
+	  background    : rgba(0, 0, 0, 0.8);     /* 文字色     */
+	}
+}

--- a/app/assets/stylesheets/users/registrations/new.scss
+++ b/app/assets/stylesheets/users/registrations/new.scss
@@ -16,6 +16,7 @@
 	width: 100%;
 	height: 1152px;
 	margin: 0 auto;
+	padding-top: 100px;
 	text-align: center;
 }
 
@@ -69,6 +70,24 @@
 
 	.actions {
 		text-align: center;
+	}
+
+	.button {
+	  display       : inline-block;
+	  font-size     : 15pt;        /* 文字サイズ */
+	  text-align    : center;      /* 文字位置   */
+	  padding       : 12px 12px;   /* 余白       */
+	  background    : rgba(0, 0, 0, 0.80);     /* 背景色     */
+	  color         : rgba(255, 255, 255, 0.8);     /* 文字色     */
+	  line-height   : 1em;         /* 1行の高さ  */
+	  transition    : .3s;         /* なめらか変化 */
+	  box-shadow    : 3px 3px 1px #666666;  /* 影の設定 */
+	  border        : 2px solid rgba(0, 0, 0, 0.8);    /* 枠の指定 */
+	}
+	.button:hover {
+	  box-shadow    : none;        /* カーソル時の影消去 */
+	  color         : rgba(0, 0, 0, 0.8);     /* 背景色     */
+	  background    : rgba(255, 255, 255, 0.8);     /* 文字色     */
 	}
 }
 

--- a/app/assets/stylesheets/users/sessions/new.scss
+++ b/app/assets/stylesheets/users/sessions/new.scss
@@ -2,6 +2,10 @@
 	background: url(/images/greed_image.jpg) no-repeat;
 	background-size: cover;
 	background-position: center center;
+
+	a {
+		text-decoration: none;
+	}
 }
 
 .for-background {
@@ -20,6 +24,7 @@
 	text-align: center;
 	width: 600px;
 	margin: 0 auto;
+	background: rgba(255,255,255,0.8)
 }
 
 .first-container, {
@@ -61,5 +66,27 @@
 		  color: #000;
 		  border-bottom: solid 2px;
 		}
+	}
+
+	.actions {
+		text-align: center;
+	}
+
+	.button {
+	  display       : inline-block;
+	  font-size     : 15pt;        /* 文字サイズ */
+	  text-align    : center;      /* 文字位置   */
+	  padding       : 12px 12px;   /* 余白       */
+	  background    : rgba(0, 0, 0, 0.80);     /* 背景色     */
+	  color         : rgba(255, 255, 255, 0.8);     /* 文字色     */
+	  line-height   : 1em;         /* 1行の高さ  */
+	  transition    : .3s;         /* なめらか変化 */
+	  box-shadow    : 3px 3px 1px #666666;  /* 影の設定 */
+	  border        : 2px solid rgba(0, 0, 0, 0.8);    /* 枠の指定 */
+	}
+	.button:hover {
+	  box-shadow    : none;        /* カーソル時の影消去 */
+	  color         : rgba(0, 0, 0, 0.8);     /* 背景色     */
+	  background    : rgba(255, 255, 255, 0.8);     /* 文字色     */
 	}
 }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-before_action :authenticate_administrator!, except: [:user_index, :user_search, :user_show]
+before_action :authenticate_administrator!, except: [:index,:user_index, :user_search, :user_show]
 
 ##　ユーザー　##
   USER_PER = 12

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,7 +88,7 @@ before_action :ensure_correct_user, only: [:destroy, :address_update, :show, :ed
 	def password_update
 	    @user = User.find(current_user.id)
 	    if @user.password == @user.current_password
-    	   redirect_to password_edit_path
+    	   redirect_to edit_password_path
 		   flash[:alert] = "パスワードが変更されていません"
 		else
 		    if @user.update_with_password(user_params)
@@ -98,7 +98,7 @@ before_action :ensure_correct_user, only: [:destroy, :address_update, :show, :ed
 		      redirect_to user_path
 		    else
 		      flash[:notice] = "パスワードが正しく設定されていません"
-		      redirect_to password_edit_path
+		      redirect_to edit_password_path
 		    end
 		end
 	end

--- a/app/views/administrators/registrations/new.html.erb
+++ b/app/views/administrators/registrations/new.html.erb
@@ -1,29 +1,44 @@
-<h2>管理者用新規登録画面</h2>
+<!-- 読み込むscssファイル -->
+<%= stylesheet_link_tag "administrators/registrations/new", :media => "all" %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<main class="main">
   <%= devise_error_messages! %>
+  <div class="container-wrapper">
+    <h2>管理者用 新規登録画面</h2>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <div class="containers">
+        <section class="first-container">
+          <div class="form-title">
+            <div class="sign-up active">
+              新規登録
+            </div>
+            <div class="sign-in">
+              <%= link_to "ログイン", new_administrator_session_path %>
+            </div>
+          </div>
+          <div class="field">
+            <%= f.label :email  %><span> ※</span><br />
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", size: "30" %>
+          </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          <div class="field">
+            <%= f.label :password %><span> ※</span>
+            <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> 文字以上)</em>
+            <% end %><br />
+            <%= f.password_field :password, autocomplete: "off", size: "30" %>
+          </div>
+
+          <div class="field">
+            <%= f.label :password_confirmation %><br />
+            <%= f.password_field :password_confirmation, autocomplete: "off" %>
+          </div>
+
+          <div class="actions">
+            <%= f.submit "新規登録" %>
+          </div>
+        </section>
+      </div>
+    <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> 文字以上)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "新規登録" %>
-  </div>
-<% end %>
-
-<%= render "administrators/shared/links" %>
+</main>

--- a/app/views/administrators/sessions/new.html.erb
+++ b/app/views/administrators/sessions/new.html.erb
@@ -1,26 +1,45 @@
-<h2>管理者用ログイン画面</h2>
+<!-- 読み込むscssファイル -->
+<%= stylesheet_link_tag "administrators/sessions/new", :media => "all" %>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<main class="main">
+  <div class="container-wrapper">
+    <h2>管理者用 ログイン画面</h2>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="containers">
+        <section class="first-container">
+          <div class="form-title">
+            <div class="sign-up">
+              <%= link_to "新規登録", new_administrator_registration_path %>
+            </div>
+            <div class="sign-in active">
+              ログイン
+            </div>
+          </div>
+          <div class="field">
+            <%= f.label :email  %><span> ※</span><br />
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", size: "30" %>
+          </div>
+
+          <div class="field">
+            <%= f.label :password %><span> ※</span>
+            <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> 文字以上)</em>
+            <% end %><br />
+            <%= f.password_field :password, autocomplete: "off", size: "30" %>
+          </div>
+
+          <% if devise_mapping.rememberable? -%>
+            <div class="field">
+              <%= f.check_box :remember_me %>
+              <%= f.label :remember_me %>
+            </div>
+          <% end -%>
+
+          <div class="actions">
+            <%= f.submit "ログイン" %>
+          </div>
+        </section>
+      </div>
+    <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end -%>
-
-  <div class="actions">
-    <%= f.submit "ログイン" %>
-  </div>
-<% end %>
-
-<%= render "administrators/shared/links" %>
+</main>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -3,7 +3,7 @@
 	<%= link_to "詳細へ", user_path(@user.id), class: "btn-sm" %>
 
 	<h4>アカウント編集</h4>
-	<%= link_to "パスワード変更はこちら", password_edit_path, class: "btn-sm" %>
+	<%= link_to "パスワード変更はこちら", edit_password_path, class: "btn-sm" %>
 	<%= form_for @user, url: user_path(@user.id), class: 'form-horizontal' do |f| %>
 	<table class='table'>
 	  	<tr>
@@ -52,7 +52,7 @@
 <% if @user.addresses.length != 3 %>
 <div class="box1">
 	住所新規追加
-	<%= form_for @addressnew, url: address_new_path do |form| %>
+	<%= form_for @addressnew, url: address_path do |form| %>
 
 	<div class="field">
 	  <%= form.label :postal_code, "郵便番号" %>

--- a/app/views/users/password_edit.html.erb
+++ b/app/views/users/password_edit.html.erb
@@ -1,28 +1,40 @@
-<h2>パスワード変更画面</h2>
+<!-- 読み込むscssファイル -->
+<%= stylesheet_link_tag "users/password_edit", :media => "all" %>
 
-<%= form_for(@user, :url => { :action => "password_update" } ) do |f| %>
+<main class="main">
+  <div class="for-background">
+    <div class="container-wrapper">
+      <%= form_for(@user, :url => { :action => "password_update" } ) do |f| %>
+        <div class="containers">
+          <section class="first-container">
+            <div class="form-title">
+              <h2>パスワード変更画面</h2>
+            </div>
+            <div class="field">
+              <%= f.label :password %><br><i>（変更しない場合は入力不要）</i><br />
+              <%= f.password_field :password, autocomplete: "off", size: "30" %>
+              <% if @minimum_password_length %>
+                <em><%= @minimum_password_length %> 文字以上</em>
+              <% end %>
+            </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(変更しない場合は入力不要)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-    <% if @minimum_password_length %>
-      <em><%= @minimum_password_length %> 文字以上</em>
-    <% end %>
+            <div class="field">
+              <%= f.label :password_confirmation %><br><i>（新しいパスワード（再確認用））</i><br />
+              <%= f.password_field :password_confirmation, autocomplete: "off", size: "30" %>
+            </div>
+
+            <div class="field">
+              <%= f.label :current_password, "現在のパスワード" %><br />
+              <%= f.password_field :current_password, autocomplete: "off", size: "30" %>
+            </div>
+
+            <div class="buttons">
+              <%= f.submit "更新する", class: "update-button" %>
+              <%= link_to "前に戻る", edit_user_path, class: "back-button" %>
+            </div>
+          </section>
+        </div>
+      <% end %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %> <i>（新しいパスワード（再確認用））</i><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password, "現在のパスワード" %> <i>(現在のパスワード)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "更新する" %>
-  </div>
-<% end %>
-
-<%= link_to "前の画面へ戻る", :back %>
+</main>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,7 +6,7 @@
   <div class="for-background">
     <div class="container-wrapper">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= devise_error_messages! %>
+      <%= devise_error_messages! %>
         <div class="containers">
           <section class="first-container">
             <div class="form-title">
@@ -87,7 +87,7 @@
             </div>
 
             <div class="actions">
-              <%= f.submit "新規登録" %>
+              <%= f.submit "新規登録", class: "button" %>
             </div>
           </section>
         </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,12 +1,10 @@
 <!-- 読み込むscssファイル -->
 <%= stylesheet_link_tag "users/sessions/new", :media => "all" %>
 
-<!-- navメニューのmargin,borderによる空白を相談 -->
 <main class="main">
   <div class="for-background">
     <div class="container-wrapper">
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <%= devise_error_messages! %>
         <div class="containers">
           <section class="first-container">
             <div class="form-title">
@@ -38,7 +36,7 @@
             <% end -%>
 
             <div class="actions">
-              <%= f.submit "ログイン" %>
+              <%= f.submit "ログイン", class: "button" %>
             </div>
           </section>
         </div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,6 +17,10 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 Rails.application.config.assets.precompile += %w( order.js )
 # ワイルドカードでうまくいかなかったため仮に
 
+# administrators
+Rails.application.config.assets.precompile += %w( administrators/registrations/new.scss )
+Rails.application.config.assets.precompile += %w( administrators/sessions/new.scss )
+
 # users
 Rails.application.config.assets.precompile += %w( users/registrations/new.scss )
 Rails.application.config.assets.precompile += %w( users/sessions/new.scss )

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -24,6 +24,8 @@ Rails.application.config.assets.precompile += %w( administrators/sessions/new.sc
 # users
 Rails.application.config.assets.precompile += %w( users/registrations/new.scss )
 Rails.application.config.assets.precompile += %w( users/sessions/new.scss )
+Rails.application.config.assets.precompile += %w( users/password_edit.scss )
+
 
 #products
 Rails.application.config.assets.precompile += %w( products/index.scss )


### PR DESCRIPTION
下記の点を変更しました。

<変更点>
①管理者側　ログイン、新規登録のCSS追加
②ユーザー側　パスワード変更画面のCSS追加
③ユーザー側　ログイン、新規登録のページデザインの統一（フォームの透過背景を統一）
④ユーザー側　ログイン、新規登録のフォーム送信ボタンデザインの変更

<対象ファイル>
①
・app/assets/stylesheets/administrators/registrations/new.scss
・app/assets/stylesheets/administrators/sessions/new.scss

②
・app/assets/stylesheets/users/password_edit.scss

③④
・app/assets/stylesheets/users/registrations/new.scss
・app/assets/stylesheets/users/sessions/new.scss